### PR TITLE
Use YamlJS to avoid packaging issue

### DIFF
--- a/plugin/package.json
+++ b/plugin/package.json
@@ -31,7 +31,8 @@
   "homepage": "https://github.com/MechanicalRock/serverless-sns-filter",
   "dependencies": {
     "cfn-response": "^1.0.1",
-    "lodash": "^4.17.4"
+    "lodash": "^4.17.4",
+    "yamljs": "^0.3.0"
   },
   "peerDependencies.Disabled": {
     "serverless": ">= 1.12.1"

--- a/plugin/spec/snsFilterPlugin.test.ts
+++ b/plugin/spec/snsFilterPlugin.test.ts
@@ -8,7 +8,7 @@ import * as Serverless from 'serverless'
 import * as AwsProvider from 'serverless/lib/plugins/aws/provider/awsProvider'
 import { SnsFilterPlugin } from '../src/snsFilterPlugin';
 import * as path from 'path';
-import * as _ from 'lodash'
+import * as _ from 'lodash';
 
 chai.use(sinonChai)
 const expect = chai.expect
@@ -95,8 +95,7 @@ describe('serverless-sns-filter/snsFilterPlugin.ts', () => {
         it('should initialise hook "after:aws:package:finalize:mergeCustomProviderResources"', () => {
             let hook = instance.hooks['after:aws:package:finalize:mergeCustomProviderResources'];
             expect(hook).not.to.be.undefined
-            expect(hook.toString()).to.contain(`return __generator`)
-            expect(hook.toString()).to.contain(`this.createDeploymentArtifacts`)
+            expect(hook).to.equal(instance.createDeploymentArtifacts)
         })
 
     });

--- a/plugin/src/snsFilterPlugin.ts
+++ b/plugin/src/snsFilterPlugin.ts
@@ -1,6 +1,8 @@
 import { Serverless } from 'serverless'
 import * as path from 'path'
 import * as _ from 'lodash'
+import * as yamlParser from 'yamljs'
+
 
 export class SnsFilterPlugin {
     options: any;
@@ -13,7 +15,7 @@ export class SnsFilterPlugin {
         this.serverless = serverless;
         this.options = options
         this.hooks = {
-            'after:aws:package:finalize:mergeCustomProviderResources': async () => await this.createDeploymentArtifacts
+            'after:aws:package:finalize:mergeCustomProviderResources': this.createDeploymentArtifacts
         }
 
         this.provider = this.serverless.getProvider('AWS');
@@ -140,7 +142,7 @@ export class SnsFilterPlugin {
     }
 
     async generateAddFilterPolicyLambdaResources(): Promise<any> {
-        let resources = (await this.serverless.yamlParser.parse(path.resolve(__dirname, "..", 'resources.yml'))).Resources
+        let resources = yamlParser.load(path.resolve(__dirname, "..", 'resources.yml')).Resources
         this.updateAddFilterPolicyLambdaFunction(resources.AddFilterPolicyLambdaFunction)
         this.updateLogGroup(resources.AddFilterPolicyLogGroup)
         this.updateIamRoleAddFilterPolicyExecution(resources.IamRoleAddFilterPolicyExecution)

--- a/plugin/yarn.lock
+++ b/plugin/yarn.lock
@@ -26,6 +26,10 @@
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/@types/diff/-/diff-3.2.2.tgz#4d6f45537322a7a420d353a0939513c7e96d14a6"
 
+"@types/es6-promise@^0.0.33":
+  version "0.0.33"
+  resolved "https://registry.yarnpkg.com/@types/es6-promise/-/es6-promise-0.0.33.tgz#280a707e62b1b6bef1a86cc0861ec63cd06c7ff3"
+
 "@types/graphql@0.10.2":
   version "0.10.2"
   resolved "https://registry.yarnpkg.com/@types/graphql/-/graphql-0.10.2.tgz#d7c79acbaa17453b6681c80c34b38fcb10c4c08c"
@@ -4553,6 +4557,13 @@ yallist@^2.1.2:
 yaml-ast-parser@0.0.34:
   version "0.0.34"
   resolved "https://registry.yarnpkg.com/yaml-ast-parser/-/yaml-ast-parser-0.0.34.tgz#d00f3cf9d773b7241409ae92a6740d1db19f49e6"
+
+yamljs@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/yamljs/-/yamljs-0.3.0.tgz#dc060bf267447b39f7304e9b2bfbe8b5a7ddb03b"
+  dependencies:
+    argparse "^1.0.7"
+    glob "^7.0.5"
 
 yargs-parser@^7.0.0:
   version "7.0.0"


### PR DESCRIPTION
Revert to the original code and use yamljs. The packaging issue is caused by serverless YAML parser