### PR TITLE
Add DependsOn to subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 To run the integration test:
 
 ```
-aws cloudformation create-stack --region ap-southeast-2 --stack-name sns-filter-it-setup --template-body file://integration-test/template.yml
+node integration-test/sns-filter-it-setup.js
 cd plugin
 yarn run setup:dev
 cd ../integration-test

--- a/integration-test/sns-filter-it-setup.js
+++ b/integration-test/sns-filter-it-setup.js
@@ -1,0 +1,17 @@
+#! /usr/local/bin/node
+const AWS=require('aws-sdk')
+const fs=require('fs')
+const path=require('path')
+
+cf = new AWS.CloudFormation({
+    region: 'ap-southeast-2',
+})
+
+let templateBody=fs.readFileSync(path.resolve(__dirname, 'template.yml'))
+console.log(`deploying ${templateBody}`)
+const params={
+    StackName: 'sns-filter-it-setup',
+    TemplateBody: templateBody.toString()
+}
+
+cf.createStack(params).promise().then(console.log)

--- a/plugin/spec/snsFilterPlugin.test.ts
+++ b/plugin/spec/snsFilterPlugin.test.ts
@@ -17,38 +17,67 @@ describe('serverless-sns-filter/snsFilterPlugin.ts', () => {
 
     let sampleCompiledCloudformationTemplate = {
         Resources:
-        {
-            HelloLambdaFunction: {
-                Type: 'AWS::Lambda::Function',
-                Properties: {
-                    FunctionName: 'serverless-sns-filter-integration-test-dev-hello',
-                }
-            },
-            SendMessageLambdaFunction: {
-                Type: 'AWS::Lambda::Function',
-                Properties: {
-                    FunctionName: 'serverless-sns-filter-integration-test-dev-sendMessage',
-                }
-            },
-            SNSTopicServerlesssnsfilterintegrationtestgreeterdev:
             {
-                Type: 'AWS::SNS::Topic',
-                Properties:
-                {
-                    TopicName: 'serverless-sns-filter-integration-test-greeter-dev',
-                    DisplayName: '',
-                    Subscription: [{
+                HelloLambdaFunction: {
+                    Type: 'AWS::Lambda::Function',
+                    Properties: {
+                        FunctionName: 'serverless-sns-filter-integration-test-dev-hello',
+                    }
+                },
+                SendMessageLambdaFunction: {
+                    Type: 'AWS::Lambda::Function',
+                    Properties: {
+                        FunctionName: 'serverless-sns-filter-integration-test-dev-sendMessage',
+                    }
+                },
+                SNSTopicServerlesssnsfilterintegrationtestgreeterdev:
+                    {
+                        Type: 'AWS::SNS::Topic',
+                        Properties:
+                            {
+                                TopicName: 'serverless-sns-filter-integration-test-greeter-dev',
+                                DisplayName: '',
+                                Subscription: [{
+                                    Endpoint: {
+                                        'Fn::GetAtt': [
+                                            "HelloLambdaFunction",
+                                            "Arn"
+                                        ]
+                                    }, Protocol: 'lambda'
+                                }]
+                            }
+                    },
+                HelloPreexistingLambdaFunction: {
+                    Type: 'AWS::Lambda::Function',
+                    Properties: {
+                        FunctionName: 'sls-plugin-it-dev-helloPreexisting',
+                    },
+                },
+                HelloPreexistingSnsSubscriptionPrexistingtopic: {
+                    Type: 'AWS::SNS::Subscription',
+                    Properties: {
+                        TopicArn: {
+                            'Fn::Join': [
+                                '',
+                                [
+                                    'arn:aws:sns:ap-southeast-2:',
+                                    {
+                                        Ref: 'AWS::AccountId'
+                                    },
+                                    ':prexisting-topic'
+                                ]
+                            ]
+                        },
+                        Protocol: 'lambda',
                         Endpoint: {
                             'Fn::GetAtt': [
-                                "HelloLambdaFunction",
-                                "Arn"
+                                'HelloPreexistingLambdaFunction',
+                                'Arn'
                             ]
-                        }, Protocol: 'lambda'
-                    }]
+                        }
+                    }
                 }
-            }
-
-        },
+            },
         Outputs: { ServerlessDeploymentBucketName: { Value: { Ref: 'ServerlessDeploymentBucket' } } }
     };
 
@@ -104,15 +133,15 @@ describe('serverless-sns-filter/snsFilterPlugin.ts', () => {
         beforeEach(async done => {
             serverless.service.functions = {
                 hello:
-                {
-                    handler: 'handler.hello',
-                    events:
-                    [{
-                        sns: 'serverless-sns-filter-integration-test-greeter-dev',
-                        filter: { attrib_one: ['foo', 'bar'] }
-                    }],
-                    name: 'serverless-sns-filter-integration-test-dev-hello',
-                }
+                    {
+                        handler: 'handler.hello',
+                        events:
+                            [{
+                                sns: 'serverless-sns-filter-integration-test-greeter-dev',
+                                filter: { attrib_one: ['foo', 'bar'] }
+                            }],
+                        name: 'serverless-sns-filter-integration-test-dev-hello',
+                    }
             }
             serverless.service.provider.compiledCloudFormationTemplate = sampleCompiledCloudformationTemplate
 
@@ -172,27 +201,27 @@ describe('serverless-sns-filter/snsFilterPlugin.ts', () => {
 
                 serverless.service.functions = {
                     hello:
-                    {
-                        handler: 'handler.hello',
-                        events:
-                        [{
-                            sns: 'serverless-sns-filter-integration-test-greeter-dev',
-                            filter: { attrib_one: ['foo', 'bar'] }
-                        }],
-                        name: 'serverless-sns-filter-integration-test-dev-hello',
-                    },
+                        {
+                            handler: 'handler.hello',
+                            events:
+                                [{
+                                    sns: 'serverless-sns-filter-integration-test-greeter-dev',
+                                    filter: { attrib_one: ['foo', 'bar'] }
+                                }],
+                            name: 'serverless-sns-filter-integration-test-dev-hello',
+                        },
                     sendMessage:
-                    {
-                        handler: 'send.with_attribute',
-                        events: [],
-                        name: 'serverless-sns-filter-integration-test-dev-sendMessage',
-                    },
+                        {
+                            handler: 'send.with_attribute',
+                            events: [],
+                            name: 'serverless-sns-filter-integration-test-dev-sendMessage',
+                        },
                     sendFilteredMessage:
-                    {
-                        handler: 'send.without_attribute',
-                        events: [],
-                        name: 'serverless-sns-filter-integration-test-dev-sendFilteredMessage',
-                    }
+                        {
+                            handler: 'send.without_attribute',
+                            events: [],
+                            name: 'serverless-sns-filter-integration-test-dev-sendFilteredMessage',
+                        }
                 };
 
                 serverless.service.provider.compiledCloudFormationTemplate = sampleCompiledCloudformationTemplate;
@@ -219,24 +248,24 @@ describe('serverless-sns-filter/snsFilterPlugin.ts', () => {
             beforeEach(async done => {
                 let functionRef: ServerlessFunctionsAggregateDefinition = {
                     hello:
-                    {
-                        handler: 'unimportant',
-                        events:
-                        [{
-                            sns: 'serverless-sns-filter-integration-test-greeter-dev',
-                            filter: { attrib_one: ['foo', 'bar'] }
-                        }],
-                        name: 'serverless-sns-filter-integration-test-dev-hello',
-                    },
+                        {
+                            handler: 'unimportant',
+                            events:
+                                [{
+                                    sns: 'serverless-sns-filter-integration-test-greeter-dev',
+                                    filter: { attrib_one: ['foo', 'bar'] }
+                                }],
+                            name: 'serverless-sns-filter-integration-test-dev-hello',
+                        },
                     sendMessage:
-                    {
-                        handler: 'unimportant',
-                        events: [{
-                            sns: 'serverless-sns-filter-integration-test-anotherTopic-dev',
-                            filter: { attrib_two: ['baz'] }
-                        }],
-                        name: 'serverless-sns-filter-integration-test-dev-sendMessage',
-                    },
+                        {
+                            handler: 'unimportant',
+                            events: [{
+                                sns: 'serverless-sns-filter-integration-test-anotherTopic-dev',
+                                filter: { attrib_two: ['baz'] }
+                            }],
+                            name: 'serverless-sns-filter-integration-test-dev-sendMessage',
+                        },
                 }
 
                 serverless.service.functions = functionRef;
@@ -316,24 +345,24 @@ describe('serverless-sns-filter/snsFilterPlugin.ts', () => {
     describe('#customResourceForFn()', () => {
         let functionRef: ServerlessFunctionsAggregateDefinition = {
             hello:
-            {
-                handler: 'unimportant',
-                events:
-                [{
-                    sns: 'serverless-sns-filter-integration-test-greeter-dev',
-                    filter: { attrib_one: ['foo', 'bar'] }
-                }],
-                name: 'serverless-sns-filter-integration-test-dev-hello',
-            },
+                {
+                    handler: 'unimportant',
+                    events:
+                        [{
+                            sns: 'serverless-sns-filter-integration-test-greeter-dev',
+                            filter: { attrib_one: ['foo', 'bar'] }
+                        }],
+                    name: 'serverless-sns-filter-integration-test-dev-hello',
+                },
             sendMessage:
-            {
-                handler: 'unimportant',
-                events: [{
-                    sns: 'serverless-sns-filter-integration-test-anotherTopic-dev',
-                    filter: { attrib_two: ['baz'] }
-                }],
-                name: 'serverless-sns-filter-integration-test-dev-sendMessage',
-            },
+                {
+                    handler: 'unimportant',
+                    events: [{
+                        sns: 'serverless-sns-filter-integration-test-anotherTopic-dev',
+                        filter: { attrib_two: ['baz'] }
+                    }],
+                    name: 'serverless-sns-filter-integration-test-dev-sendMessage',
+                },
         }
         let instance: SnsFilterPlugin;
         beforeEach(() => {
@@ -514,22 +543,22 @@ describe('serverless-sns-filter/snsFilterPlugin.ts', () => {
         it('should return an empty list when the function ref has no sns filters defined', () => {
             let functionRef: ServerlessFunctionsAggregateDefinition = {
                 hello:
-                {
-                    handler: 'handler.hello',
-                    events:
-                    [{
-                        sns: 'serverless-sns-filter-integration-test-greeter-dev',
-                    }],
-                    name: 'serverless-sns-filter-integration-test-dev-hello',
-                },
+                    {
+                        handler: 'handler.hello',
+                        events:
+                            [{
+                                sns: 'serverless-sns-filter-integration-test-greeter-dev',
+                            }],
+                        name: 'serverless-sns-filter-integration-test-dev-hello',
+                    },
                 sendMessage:
-                {
-                    handler: 'send.with_attribute',
-                    events: [{
-                        sns: 'serverless-sns-filter-integration-test-greeter-dev',
-                    }],
-                    name: 'serverless-sns-filter-integration-test-dev-sendMessage',
-                },
+                    {
+                        handler: 'send.with_attribute',
+                        events: [{
+                            sns: 'serverless-sns-filter-integration-test-greeter-dev',
+                        }],
+                        name: 'serverless-sns-filter-integration-test-dev-sendMessage',
+                    },
             }
 
             let result = instance.functionsWithSnsFilters(functionRef)
@@ -540,23 +569,23 @@ describe('serverless-sns-filter/snsFilterPlugin.ts', () => {
         it('should return a function ref with sns filters defined', () => {
             let functionRef: ServerlessFunctionsAggregateDefinition = {
                 hello:
-                {
-                    handler: 'handler.hello',
-                    events:
-                    [{
-                        sns: 'serverless-sns-filter-integration-test-greeter-dev',
-                        filter: { attrib_one: ['foo', 'bar'] }
-                    }],
-                    name: 'serverless-sns-filter-integration-test-dev-hello',
-                },
+                    {
+                        handler: 'handler.hello',
+                        events:
+                            [{
+                                sns: 'serverless-sns-filter-integration-test-greeter-dev',
+                                filter: { attrib_one: ['foo', 'bar'] }
+                            }],
+                        name: 'serverless-sns-filter-integration-test-dev-hello',
+                    },
                 sendMessage:
-                {
-                    handler: 'send.with_attribute',
-                    events: [{
-                        sns: 'serverless-sns-filter-integration-test-greeter-dev',
-                    }],
-                    name: 'serverless-sns-filter-integration-test-dev-sendMessage',
-                },
+                    {
+                        handler: 'send.with_attribute',
+                        events: [{
+                            sns: 'serverless-sns-filter-integration-test-greeter-dev',
+                        }],
+                        name: 'serverless-sns-filter-integration-test-dev-sendMessage',
+                    },
             }
 
             let result = instance.functionsWithSnsFilters(functionRef)
@@ -568,32 +597,32 @@ describe('serverless-sns-filter/snsFilterPlugin.ts', () => {
         it('should return all function ref with sns filters defined', () => {
             let functionRef: ServerlessFunctionsAggregateDefinition = {
                 hello:
-                {
-                    handler: 'handler.hello',
-                    events:
-                    [{
-                        sns: 'serverless-sns-filter-integration-test-greeter-dev',
-                        filter: { attrib_one: ['foo', 'bar'] }
-                    }],
-                    name: 'serverless-sns-filter-integration-test-dev-hello',
-                },
+                    {
+                        handler: 'handler.hello',
+                        events:
+                            [{
+                                sns: 'serverless-sns-filter-integration-test-greeter-dev',
+                                filter: { attrib_one: ['foo', 'bar'] }
+                            }],
+                        name: 'serverless-sns-filter-integration-test-dev-hello',
+                    },
                 noFilter:
-                {
-                    handler: 'send.with_attribute',
-                    events: [{
-                        http: "GET hello",
-                    }],
-                    name: 'serverless-sns-filter-integration-test-dev-sendMessage',
-                },
+                    {
+                        handler: 'send.with_attribute',
+                        events: [{
+                            http: "GET hello",
+                        }],
+                        name: 'serverless-sns-filter-integration-test-dev-sendMessage',
+                    },
                 sendMessage:
-                {
-                    handler: 'send.with_attribute',
-                    events: [{
-                        sns: 'serverless-sns-filter-integration-test-greeter-dev',
-                        filter: { attrib_two: ['baz', 'boo'] }
-                    }],
-                    name: 'serverless-sns-filter-integration-test-dev-sendMessage',
-                },
+                    {
+                        handler: 'send.with_attribute',
+                        events: [{
+                            sns: 'serverless-sns-filter-integration-test-greeter-dev',
+                            filter: { attrib_two: ['baz', 'boo'] }
+                        }],
+                        name: 'serverless-sns-filter-integration-test-dev-sendMessage',
+                    },
             }
 
             let result = instance.functionsWithSnsFilters(functionRef)
@@ -703,9 +732,94 @@ describe('serverless-sns-filter/snsFilterPlugin.ts', () => {
             })
 
             it('should not add a dependency on the topic', () => {
-                expect(this.customResource.DependsOn.length).to.equal(2)
+                expect(this.customResource.DependsOn).not.to.include('SNSTopicServerlesssnsfilterintegrationtestgreeterdev')
+            })
+
+            it('should add a dependency on the AWS::SNS::Subscription', () => {
+                expect(this.customResource.DependsOn).to.include('HelloPreexistingSnsSubscriptionPrexistingtopic')
             })
         })
 
+    })
+
+    describe('#getAllSubscriptionResourceKeys', () => {
+        describe('When no AWS::Topic::Subscriptions resources defined', () => {
+            let noSubscriptionResources = {
+                HelloLambdaFunction: {
+                    Type: 'AWS::Lambda::Function',
+                },
+                SNSTopicServerlesssnsfilterintegrationtestgreeterdev: {
+                    Type: 'AWS::SNS::Topic',
+                },
+            };
+
+            let result: string[];
+            let instance: SnsFilterPlugin;
+            beforeEach( () => {
+                instance = new SnsFilterPlugin(serverless, {});
+                result = instance.getAllSubscriptionResourceKeys(noSubscriptionResources)
+            })
+
+            it('should return []', () => {
+                expect(result).to.be.an('array').that.has.length(0)
+            })
+
+        })
+
+        describe('When a single AWS::Topic::Subscriptions resources defined', () => {
+            let noSubscriptionResources = {
+                HelloLambdaFunction: {
+                    Type: 'AWS::Lambda::Function',
+                },
+                SNSTopicServerlesssnsfilterintegrationtestgreeterdev: {
+                    Type: 'AWS::SNS::Topic',
+                },
+                HelloPreexistingSnsSubscriptionPrexistingtopic: {
+                    Type: 'AWS::SNS::Subscription',
+                }
+            };
+
+            let result: string[];
+            let instance: SnsFilterPlugin;
+            beforeEach( () => {
+                    instance = new SnsFilterPlugin(serverless, {});
+                result = instance.getAllSubscriptionResourceKeys(noSubscriptionResources)
+            })
+
+            it('should return the resource key', () => {
+                expect(result).to.be.an('array').that.has.length(1)
+                expect(result).to.include('HelloPreexistingSnsSubscriptionPrexistingtopic')
+            })
+
+        })
+
+        describe('When multiple AWS::Topic::Subscriptions resources defined', () => {
+            let noSubscriptionResources = {
+                HelloLambdaFunction: {
+                    Type: 'AWS::Lambda::Function',
+                },
+                SNSTopicServerlesssnsfilterintegrationtestgreeterdev: {
+                    Type: 'AWS::SNS::Topic',
+                },
+                subscription1: {
+                    Type: 'AWS::SNS::Subscription',
+                },
+                subscription2: {
+                    Type: 'AWS::SNS::Subscription',
+                }
+            };
+
+            let result: string[];
+            let instance: SnsFilterPlugin;
+            beforeEach( () => {
+                    instance = new SnsFilterPlugin(serverless, {});
+                result = instance.getAllSubscriptionResourceKeys(noSubscriptionResources)
+            })
+
+            it('should return the resource key', () => {
+                expect(result).to.include.members(['subscription1','subscription2'])
+            })
+
+        })
     })
 })


### PR DESCRIPTION
Fixes issue where deployment fails when subscription to pre-existing topic added at the same time as a filter

Ensures that custom policies are applied after all subscriptions/topics are created/updated.