### PR TITLE
Don't silently do the wrong thing if our code is broken

### DIFF
--- a/plugin/src/snsFilterPlugin.ts
+++ b/plugin/src/snsFilterPlugin.ts
@@ -28,8 +28,7 @@ export class SnsFilterPlugin {
         let keypair = _.toPairs(resources).filter(topic).find(matchingName)
         if (!keypair) {
             // should not happen
-            // throw new Error(`No matching AWS::Lambda::Function with name ${functionName} found`)
-            keypair = ['unknown', 'unknown']
+            throw new Error(`No matching AWS::SNS::Topic with name ${topicName} found`)
         }
         return keypair[0]
     }
@@ -40,8 +39,7 @@ export class SnsFilterPlugin {
         let keypair = _.toPairs(resources).filter(lambdaFunctions).find(matchingName)
         if (!keypair) {
             // should not happen
-            // throw new Error(`No matching AWS::Lambda::Function with name ${functionName} found`)
-            keypair = ['unknown', 'unknown']
+            throw new Error(`No matching AWS::Lambda::Function with name ${functionName} found`)
         }
         return keypair[0]
 


### PR DESCRIPTION
If it turns out that a user has done something unusual with their event subscription, it's better to explicitly throw an error at the point where we detect the problem, rather than insert an invalid reference into the Cloud Formation file