### PR TITLE
Allow for enhanced object model for an SNS event.

### DIFF
--- a/plugin/spec/snsFilterPlugin.test.ts
+++ b/plugin/spec/snsFilterPlugin.test.ts
@@ -51,7 +51,7 @@ describe('serverless-sns-filter/snsFilterPlugin.ts', () => {
                     "Type": "AWS::SNS::Topic",
                     "Properties": {
                         "TopicName": "serverless-sns-filter-integration-test-anotherTopic-dev",
-                        "DisplayName": "",
+                        "DisplayName": "Another Topic (tm)",
                         "Subscription": [
                         {
                             "Endpoint": {
@@ -285,7 +285,10 @@ describe('serverless-sns-filter/snsFilterPlugin.ts', () => {
                         {
                             handler: 'unimportant',
                             events: [{
-                                sns: 'serverless-sns-filter-integration-test-anotherTopic-dev',
+                                sns: {
+                                    topicName: 'serverless-sns-filter-integration-test-anotherTopic-dev',
+                                    displayName: 'Another Topic (tm)'
+                                },
                                 filter: { attrib_two: ['baz'] }
                             }],
                             name: 'serverless-sns-filter-integration-test-dev-sendMessage',
@@ -382,7 +385,10 @@ describe('serverless-sns-filter/snsFilterPlugin.ts', () => {
                 {
                     handler: 'unimportant',
                     events: [{
-                        sns: 'serverless-sns-filter-integration-test-anotherTopic-dev',
+                        sns: {
+                            topicName: 'serverless-sns-filter-integration-test-anotherTopic-dev',
+                            displayName: 'Another Topic (tm)'
+                        },
                         filter: { attrib_two: ['baz'] }
                     }],
                     name: 'serverless-sns-filter-integration-test-dev-sendMessage',

--- a/plugin/src/snsFilterPlugin.ts
+++ b/plugin/src/snsFilterPlugin.ts
@@ -67,14 +67,14 @@ export class SnsFilterPlugin {
             // subscriptionRefs.forEach(ref => )
             dependencies.push(...subscriptionRefs)
         } else {
+            let snsTopicName = matchingSnsEvent.sns.topicName ? matchingSnsEvent.sns.topicName : matchingSnsEvent.sns;
             snsTopicArn = {
                 "Fn::Join": [
                     '', [
-                        "arn:aws:sns:", { "Ref": "AWS::Region" }, ":", { "Ref": "AWS::AccountId" }, `:${matchingSnsEvent.sns}`
+                        "arn:aws:sns:", { "Ref": "AWS::Region" }, ":", { "Ref": "AWS::AccountId" }, `:${snsTopicName}`
                     ]
                 ]
             }
-            let snsTopicName = matchingSnsEvent.sns;
             let topicRef = this.getTopicCloudformationResourceKey(snsTopicName, this.serverless.service.provider.compiledCloudFormationTemplate.Resources)
             dependencies.push(topicRef)
         }


### PR DESCRIPTION
It is possible to specify the name for a serverless-generated SNS topic
by using the `topicName` and `displayName` fields. This means we
should look for topicName even if there is no `arn` field.

https://serverless.com/framework/docs/providers/aws/events/sns#setting-a-display-name